### PR TITLE
Increase editor view and scale player

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Controls:
 ## Custom Player Skin
 
 You can create your own player appearance using `editeur.py`. Run the editor and
-draw a 40x60 pixel skin with the palette provided. Each pixel is displayed as a 4x4 square to make drawing easier. Either press `S` or use the
+draw a 40x60 pixel skin with the palette provided. Each pixel is displayed as a 16x16 square to make drawing easier. Either press `S` or use the
 "Sauvegarder" button to save your skin to `player_skin.png`. When you start the
-game again, this image will be loaded and used for the player sprite.
+game again, each of these pixels is scaled so the player sprite appears four times larger.
 
 ```bash
 python3 editeur.py

--- a/editeur.py
+++ b/editeur.py
@@ -1,7 +1,7 @@
 import pygame
 import os
 
-CELL_SIZE = 4
+CELL_SIZE = 16  # enlarge each cell for a bigger window
 GRID_WIDTH = 40
 GRID_HEIGHT = 60
 WIDTH = CELL_SIZE * GRID_WIDTH

--- a/game.py
+++ b/game.py
@@ -20,8 +20,9 @@ SKY_TOP = (135, 206, 250)
 SKY_BOTTOM = (0, 120, 255)
 
 # Player settings
-PLAYER_WIDTH = 40
-PLAYER_HEIGHT = 60
+# Scale the player sprite to appear larger in game
+PLAYER_WIDTH = 40 * 4
+PLAYER_HEIGHT = 60 * 4
 PLAYER_SPEED = 5
 JUMP_POWER = 15
 GRAVITY = 1
@@ -49,11 +50,11 @@ class Player(pygame.sprite.Sprite):
             self.image = pygame.Surface((PLAYER_WIDTH, PLAYER_HEIGHT))
             self.image.fill(GREEN)
             # draw a simple face as a placeholder texture
-            eye = pygame.Surface((8, 8))
+            eye = pygame.Surface((32, 32))
             eye.fill(WHITE)
-            self.image.blit(eye, (10, 15))
-            self.image.blit(eye, (PLAYER_WIDTH - 18, 15))
-            pygame.draw.rect(self.image, BLACK, (8, PLAYER_HEIGHT - 15, PLAYER_WIDTH - 16, 5))
+            self.image.blit(eye, (40, 60))
+            self.image.blit(eye, (PLAYER_WIDTH - 72, 60))
+            pygame.draw.rect(self.image, BLACK, (32, PLAYER_HEIGHT - 60, PLAYER_WIDTH - 64, 20))
         self.rect = self.image.get_rect()
         self.rect.centerx = WIDTH // 2
         # start the player on the ground


### PR DESCRIPTION
## Summary
- expand the pixel editor window by increasing each grid cell size
- make the player sprite four times larger in the game
- update placeholder graphics accordingly
- document new scaling behavior in README

## Testing
- `python3 -m py_compile game.py editeur.py`