### PR TITLE
Shrink player sprite and adjust skin editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ Controls:
 
 ## Custom Player Skin
 
-You can create your own player appearance using `editeur.py`. Run the editor and
-draw a 40x60 pixel skin with the palette provided. Each pixel is displayed as a 16x16 square to make drawing easier. Either press `S` or use the
+You can create your own player appearance using `editeur.py`. The editor now provides a 10x15 grid. Each cell you color becomes a 4×4 block in the final 40x60 image used by the game. Cells are displayed as 16×16 squares to make drawing easier. Either press `S` or use the
 "Sauvegarder" button to save your skin to `player_skin.png`. When you start the
-game again, each of these pixels is scaled so the player sprite appears four times larger.
+game again, the sprite is displayed at this size without additional scaling.
 
 ```bash
 python3 editeur.py

--- a/editeur.py
+++ b/editeur.py
@@ -2,8 +2,11 @@ import pygame
 import os
 
 CELL_SIZE = 16  # enlarge each cell for a bigger window
-GRID_WIDTH = 40
-GRID_HEIGHT = 60
+SCALE = 4
+GRID_WIDTH = 40 // SCALE
+GRID_HEIGHT = 60 // SCALE
+BASE_WIDTH = GRID_WIDTH * SCALE
+BASE_HEIGHT = GRID_HEIGHT * SCALE
 WIDTH = CELL_SIZE * GRID_WIDTH
 CANVAS_HEIGHT = CELL_SIZE * GRID_HEIGHT
 PALETTE_SIZE = 40
@@ -54,10 +57,13 @@ def main():
                     running = False
                 if event.key == pygame.K_s:
                     # save skin
-                    surface = pygame.Surface((GRID_WIDTH, GRID_HEIGHT), pygame.SRCALPHA)
+                    surface = pygame.Surface((BASE_WIDTH, BASE_HEIGHT), pygame.SRCALPHA)
                     for y in range(GRID_HEIGHT):
                         for x in range(GRID_WIDTH):
-                            surface.set_at((x, y), grid[y][x])
+                            color = grid[y][x]
+                            for dy in range(SCALE):
+                                for dx in range(SCALE):
+                                    surface.set_at((x * SCALE + dx, y * SCALE + dy), color)
                     pygame.image.save(surface, "player_skin.png")
                     print("Skin sauvegarde dans player_skin.png")
             if event.type == pygame.MOUSEBUTTONDOWN:
@@ -77,10 +83,13 @@ def main():
                             selected_color = PALETTE_COLORS[index]
                 else:
                     if save_button.collidepoint(mx, my):
-                        surface = pygame.Surface((GRID_WIDTH, GRID_HEIGHT), pygame.SRCALPHA)
+                        surface = pygame.Surface((BASE_WIDTH, BASE_HEIGHT), pygame.SRCALPHA)
                         for y in range(GRID_HEIGHT):
                             for x in range(GRID_WIDTH):
-                                surface.set_at((x, y), grid[y][x])
+                                color = grid[y][x]
+                                for dy in range(SCALE):
+                                    for dx in range(SCALE):
+                                        surface.set_at((x * SCALE + dx, y * SCALE + dy), color)
                         pygame.image.save(surface, "player_skin.png")
                         print("Skin sauvegarde dans player_skin.png")
 

--- a/game.py
+++ b/game.py
@@ -20,9 +20,8 @@ SKY_TOP = (135, 206, 250)
 SKY_BOTTOM = (0, 120, 255)
 
 # Player settings
-# Scale the player sprite to appear larger in game
-PLAYER_WIDTH = 40 * 4
-PLAYER_HEIGHT = 60 * 4
+PLAYER_WIDTH = 40
+PLAYER_HEIGHT = 60
 PLAYER_SPEED = 5
 JUMP_POWER = 15
 GRAVITY = 1
@@ -50,11 +49,15 @@ class Player(pygame.sprite.Sprite):
             self.image = pygame.Surface((PLAYER_WIDTH, PLAYER_HEIGHT))
             self.image.fill(GREEN)
             # draw a simple face as a placeholder texture
-            eye = pygame.Surface((32, 32))
+            eye = pygame.Surface((8, 8))
             eye.fill(WHITE)
-            self.image.blit(eye, (40, 60))
-            self.image.blit(eye, (PLAYER_WIDTH - 72, 60))
-            pygame.draw.rect(self.image, BLACK, (32, PLAYER_HEIGHT - 60, PLAYER_WIDTH - 64, 20))
+            self.image.blit(eye, (10, 15))
+            self.image.blit(eye, (PLAYER_WIDTH - 18, 15))
+            pygame.draw.rect(
+                self.image,
+                BLACK,
+                (8, PLAYER_HEIGHT - 15, PLAYER_WIDTH - 16, 5),
+            )
         self.rect = self.image.get_rect()
         self.rect.centerx = WIDTH // 2
         # start the player on the ground


### PR DESCRIPTION
## Summary
- revert player sprite size to original 40x60 pixels
- scale placeholder face features accordingly
- shrink the skin editor grid by a factor of four and upscale on save
- document the new editor behaviour and player size in README

## Testing
- `python3 -m py_compile game.py editeur.py`
