### PR TITLE
Fix ground collision outside platform

### DIFF
--- a/game.py
+++ b/game.py
@@ -76,7 +76,10 @@ class Player(pygame.sprite.Sprite):
         # are ignored to avoid creating an "invisible" collision surface.
         self.rect.y += dy
         self.on_ground = False
-        if self.rect.bottom >= GROUND_Y:
+        if (
+            0 <= self.rect.centerx <= WORLD_WIDTH
+            and self.rect.bottom >= GROUND_Y
+        ):
             self.rect.bottom = GROUND_Y
             self.vel_y = 0
             self.on_ground = True


### PR DESCRIPTION
## Summary
- restrict ground collision to the white platform width so the player can fall when leaving it

## Testing
- `python3 -m py_compile game.py editeur.py`


------
https://chatgpt.com/codex/tasks/task_b_683f6176bc408326900b328c648eabef